### PR TITLE
Fix: Replace vague TODO comments with descriptive module information

### DIFF
--- a/CLAUDE_CODE_HANDOFF.md
+++ b/CLAUDE_CODE_HANDOFF.md
@@ -136,11 +136,11 @@ janus/
 └── src/
     ├── cli.ts            # Entry point
     ├── types.ts          # TypeScript interfaces
-    ├── context-bridge/   # TODO
-    ├── orchestrator/     # TODO
-    ├── swarms/{scout,council,executor}/  # TODO
-    ├── providers/        # TODO
-    └── utils/            # TODO
+    ├── context-bridge/   # Git-backed state & session management
+    ├── orchestrator/     # Main orchestration engine
+    ├── swarms/{scout,council,executor}/  # Multi-model AI swarms
+    ├── providers/        # API adapters (Claude, GPT, Gemini)
+    └── utils/            # Shared utilities & helpers
 ```
 
 ---


### PR DESCRIPTION
Replace placeholder 'TODO' comments in the src/ directory structure with clear descriptions of what each module should do:
- context-bridge: Git-backed state & session management
- orchestrator: Main orchestration engine
- swarms: Multi-model AI swarms
- providers: API adapters (Claude, GPT, Gemini)
- utils: Shared utilities & helpers

This makes the handoff document more informative for the next developer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces vague TODO comments with specific module descriptions in `CLAUDE_CODE_HANDOFF.md`'s `src/` directory structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8774d5ffa7ed4eb500f7b63fd8c6b8ae63cab62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->